### PR TITLE
Treat a pipe as attributes only where attributes can go

### DIFF
--- a/crates/usfm3/src/builder.rs
+++ b/crates/usfm3/src/builder.rs
@@ -346,7 +346,17 @@ impl<'a> LowerCtx<'a> {
         _parent_id: CstNodeId,
         is_block: bool,
         close_span: &mut Option<Span>,
-        attributes: &mut Vec<Attribute<'a>>,
+        // `None` when the node being built has nowhere to put attributes.
+        //
+        // `Node::Para`, `Node::Sidebar`, `Node::TableRow`, `Node::TableCell`
+        // and `Node::Unknown` have no attributes field, so whatever was
+        // collected for them used to be discarded on return — along with the
+        // source text it was parsed from.
+        //
+        // An `Option` rather than a convention means a caller with nowhere to
+        // put them cannot lose text by forgetting: it passes `None`, and the
+        // text is kept as content instead.
+        mut attributes: Option<&mut Vec<Attribute<'a>>>,
         marker_name: &str,
     ) -> Vec<SpannedNode<'a>> {
         let mut children: Vec<SpannedNode<'a>> = Vec::new();
@@ -420,6 +430,27 @@ impl<'a> LowerCtx<'a> {
                 }
                 CstKind::AttributesToken => {
                     let text = self.doc.source_text(child_id);
+
+                    // Nowhere to put them, so this was never an attribute
+                    // block: attributes attach to a marker closed with
+                    // `\marker*`, and there is none here.
+                    //
+                    // Kept as content, which is what the `None` arm below
+                    // already does for an attribute string that will not
+                    // parse. Same reasoning, same treatment — the caller can
+                    // decide what a stray `|` meant, and cannot do that if the
+                    // parser has already thrown it away.
+                    let Some(attributes) = attributes.as_deref_mut() else {
+                        if pending_space {
+                            pending_space = false;
+                            Self::append_text_to(&mut children, " ");
+                        }
+                        Self::append_text_to(&mut children, text);
+                        after_open = false;
+                        after_close = false;
+                        continue;
+                    };
+
                     let parsed = match parse_attributes(text) {
                         Some(attrs) => attrs,
                         None => {
@@ -733,15 +764,8 @@ impl<'a> LowerCtx<'a> {
 
         let is_block = true;
         let mut close_span = None;
-        let mut attributes = Vec::new();
-        let children = self.collect_content(
-            node,
-            id,
-            is_block,
-            &mut close_span,
-            &mut attributes,
-            marker.as_str(),
-        );
+        let children =
+            self.collect_content(node, id, is_block, &mut close_span, None, marker.as_str());
 
         let (content, children) = split_nodes(children);
         Some(SpannedNode::new(
@@ -783,7 +807,7 @@ impl<'a> LowerCtx<'a> {
             id,
             false,
             &mut close_span,
-            &mut attributes,
+            Some(&mut attributes),
             marker.as_str(),
         );
 
@@ -863,8 +887,14 @@ impl<'a> LowerCtx<'a> {
         let ref_marker = MarkerName::from("ref");
         let mut close_span = None;
         let mut attributes = Vec::new();
-        let children =
-            self.collect_content(node, id, false, &mut close_span, &mut attributes, "ref");
+        let children = self.collect_content(
+            node,
+            id,
+            false,
+            &mut close_span,
+            Some(&mut attributes),
+            "ref",
+        );
 
         self.check_close_diagnostics(id, node, &ref_marker, &close_span);
 
@@ -1084,7 +1114,7 @@ impl<'a> LowerCtx<'a> {
             id,
             false,
             &mut close_span,
-            &mut attributes,
+            Some(&mut attributes),
             marker.as_str(),
         );
 
@@ -1113,15 +1143,8 @@ impl<'a> LowerCtx<'a> {
         marker: &MarkerName,
     ) -> Option<SpannedNode<'a>> {
         let mut close_span = None;
-        let mut attributes = Vec::new();
-        let children = self.collect_content(
-            node,
-            id,
-            false,
-            &mut close_span,
-            &mut attributes,
-            marker.as_str(),
-        );
+        let children =
+            self.collect_content(node, id, false, &mut close_span, None, marker.as_str());
 
         if close_span.is_none() {
             self.push_diagnostic(|| {
@@ -1253,15 +1276,8 @@ impl<'a> LowerCtx<'a> {
         marker: &MarkerName,
     ) -> Option<SpannedNode<'a>> {
         let mut close_span = None;
-        let mut attributes = Vec::new();
-        let mut children = self.collect_content(
-            node,
-            id,
-            true,
-            &mut close_span,
-            &mut attributes,
-            marker.as_str(),
-        );
+        let mut children =
+            self.collect_content(node, id, true, &mut close_span, None, marker.as_str());
 
         // Per spec, trim trailing whitespace from the last cell's content
         // (whitespace before the next \tr is structural, not content)
@@ -1292,15 +1308,8 @@ impl<'a> LowerCtx<'a> {
         marker: &MarkerName,
     ) -> Option<SpannedNode<'a>> {
         let mut close_span = None;
-        let mut attributes = Vec::new();
-        let children = self.collect_content(
-            node,
-            id,
-            false,
-            &mut close_span,
-            &mut attributes,
-            marker.as_str(),
-        );
+        let children =
+            self.collect_content(node, id, false, &mut close_span, None, marker.as_str());
 
         let mut spans = SourceSpans::node(node.span.clone());
         if let Some(cs) = close_span {
@@ -1382,15 +1391,8 @@ impl<'a> LowerCtx<'a> {
         }
 
         let mut close_span = None;
-        let mut attributes = Vec::new();
-        let children = self.collect_content(
-            node,
-            id,
-            false,
-            &mut close_span,
-            &mut attributes,
-            marker.as_str(),
-        );
+        let children =
+            self.collect_content(node, id, false, &mut close_span, None, marker.as_str());
 
         self.check_close_diagnostics(id, node, marker, &close_span);
 

--- a/crates/usfm3/tests/integration.rs
+++ b/crates/usfm3/tests/integration.rs
@@ -1241,3 +1241,97 @@ fn ast_table_grouping() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// A `|` with no marker to attach to is content, not an attribute block
+// ---------------------------------------------------------------------------
+
+// https://ubsicap.github.io/usfm/attributes/index.html
+// Attributes attach to a character marker or a milestone — something closed
+// with `\marker*`. Where there is no such marker there is nothing for them to
+// attach to, so the text is kept as content, exactly as it already is for an
+// attribute string that will not parse.
+
+#[test]
+fn a_pipe_in_paragraph_text_is_not_an_attribute_block() {
+    let usfm = "\\id GEN\n\\c 1\n\\p\n\\v 1 before| after more words";
+
+    let vref = parse_to_vref(usfm);
+    assert_eq!(
+        vref.get("GEN 1:1").and_then(|v| v.as_str()),
+        Some("before| after more words")
+    );
+}
+
+/// The quieter half: `parse_attributes("|")` returns an empty list rather than
+/// `None`, so a trailing pipe was discarded even with nothing after it to lose.
+#[test]
+fn a_pipe_at_the_end_of_a_line_is_kept() {
+    let usfm = "\\id GEN\n\\c 1\n\\p\n\\v 1 a sentence|";
+
+    let vref = parse_to_vref(usfm);
+    assert_eq!(
+        vref.get("GEN 1:1").and_then(|v| v.as_str()),
+        Some("a sentence|")
+    );
+}
+
+#[test]
+fn a_pipe_in_a_table_cell_is_kept() {
+    let usfm = "\\id GEN\n\\c 1\n\\tr \\tc1 first| second \\tc2 third";
+
+    let usj = parse_to_usj(usfm);
+    let cells = collect_by_type(&usj, "table:cell");
+    let text: String = cells
+        .iter()
+        .flat_map(|c| c["content"].as_array().cloned().unwrap_or_default())
+        .filter_map(|v| v.as_str().map(str::to_owned))
+        .collect();
+
+    assert!(text.contains("first| second"), "{text:?}");
+    assert!(text.contains("third"), "{text:?}");
+}
+
+/// The regression guard: inside a character marker a pipe still introduces
+/// attributes, and they still parse.
+#[test]
+fn a_pipe_inside_a_character_marker_is_still_an_attribute_block() {
+    let usfm = "\\id GEN\n\\c 1\n\\p\n\\v 1 \\w beginning|lemma=\"H7225\"\\w* now";
+
+    let usj = parse_to_usj(usfm);
+    let chars = collect_by_type(&usj, "char");
+    let w = chars
+        .iter()
+        .find(|c| c["marker"] == "w")
+        .expect("the \\w node");
+
+    let attrs = w["attributes"].as_array().expect("attributes");
+    let lemma = attrs
+        .iter()
+        .find(|a| a["key"] == "lemma")
+        .expect("the lemma attribute");
+    assert_eq!(lemma["value"], "H7225");
+
+    let vref = parse_to_vref(usfm);
+    let text = vref
+        .get("GEN 1:1")
+        .and_then(|v| v.as_str())
+        .expect("verse text");
+    assert!(
+        !text.contains('|') && !text.contains("lemma"),
+        "attribute syntax leaked into the text: {text:?}"
+    );
+}
+
+/// Restored text keeps its place, rather than collecting at the end of the
+/// paragraph.
+#[test]
+fn text_after_a_pipe_keeps_its_position() {
+    let usfm = "\\id GEN\n\\c 1\n\\p\n\\v 1 one| two \\add three\\add* four";
+
+    let vref = parse_to_vref(usfm);
+    assert_eq!(
+        vref.get("GEN 1:1").and_then(|v| v.as_str()),
+        Some("one| two three four")
+    );
+}


### PR DESCRIPTION
`collect_content` parses an attribute block at every `|` and pushes the result into the vector its caller supplied. Five callers have nowhere to put one — `Node::Para`, `Node::Sidebar`, `Node::TableRow`, `Node::TableCell` and `Node::Unknown` have no attributes field — so they allocated the vector, passed it in, and dropped it on return. The source text went with it, with no diagnostic:

```
\v 11 before| after more words   →   [verse, " before"]
```

### The neighbouring case already gets this right

When `parse_attributes` returns `None`, the same match arm appends the raw string as content and raises `malformed_attributes` — on the reasoning that the caller should decide what unparseable attribute text meant. An attribute block that has nowhere to go is the same situation and never got the same treatment. This change makes the two consistent; it isn't a new opinion about what a `|` means.

There's a quieter half. `parse_attributes("|")` returns `Some(vec![])` rather than `None`, so the empty case was discarded too — a trailing pipe vanished even with nothing after it to lose. That's the majority of them, and the reason this is easy to miss when spot-checking output.

### The approach

Rather than test the marker at the point of use, the `attributes` parameter of `collect_content` becomes `Option<&mut Vec<Attribute>>`. A caller with somewhere to put attributes passes `Some`; one without passes `None`, and the text is kept as content.

That makes the failure unreachable rather than merely fixed: a node type added later can't lose text by forgetting a rule, because there's no vector to discard. The five callers that used to allocate one no longer do.

I first tried keying off the existing `is_block` flag, which looks right — `lower_para` and `lower_table_row` are its only `true` callers. It's wrong: `lower_table_cell` passes `false` and *also* discards attributes, so a pipe in a table cell still vanished. The `Option` has no such gap, and there's a test for that case.

### Testing

Five integration tests in `tests/integration.rs`, using the existing `parse_to_vref` / `parse_to_usj` helpers. Two are regression guards rather than demonstrations:

- `\w beginning|lemma="H7225"\w*` still parses its attributes, with nothing leaking into the text
- `one| two \add three\add* four` keeps its order, rather than the restored text collecting at the end of the paragraph

Bridgeconn conformance is unchanged — the same nine unexpected failures before and after (fixtures fetched with the `npx degit` line from `tests/bridgeconn.rs`; without them that suite panics on a missing directory rather than reporting a pass, which is worth knowing when checking this).

### A note on the diff

`builder.rs` is +52/−50, and about 39 of those lines are rustfmt reflow: replacing `&mut attributes,` with `None,` and deleting the now-dead locals shortens five argument lists below `max_width`, so rustfmt collapses them. `git diff -w` cuts through most of it. Keeping the original layout fails `cargo fmt --all -- --check`, so it isn't a style choice I can defer.

### How I found it

Bridgeconn's `70-3JNsanasm.usfm`, an Assamese translation, uses `U+007C` as a sentence separator throughout: 18 of them, plus every word following one mid-line, disappear from the parse. Whether `U+007C` is the right character in that file is a separate question — the Devanagari danda is `U+0964`, which the rest of that corpus uses 7,701 times — but it doesn't seem like a reason for the parser to delete the surrounding text without saying so.

Happy to add an Information-level diagnostic when a pipe is kept as content, if you'd rather it were reported as well as preserved. I left it out to keep the change to "don't lose text", which needs no agreement about what a stray pipe meant.
